### PR TITLE
Build for Jenkins 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A Jenkins plugin for analyzing the historical console output of a Job with the g
 
 
 ## Requirements:
- + Jenkins Version >= `1.580.1`
+ + Jenkins Version >= `2.164.1`
  + [Timestamper Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Timestamper)
 
 ## What it does:

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<FindBugsFilter>
-  <Bug code="BC"/>
-  <Bug code="SnVI"/>
-  <Bug code="CN"/>
-  <Bug code="Eq"/>
-</FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -126,13 +126,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <configuration>
-                    <excludeFilterFile>findbugs-exclude.xml</excludeFilterFile>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
                 <version>1.5</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/maven-v4_0_0.xsd http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <scm>
@@ -12,13 +13,16 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.11</version>
+        <version>3.50</version>
+        <relativePath />
     </parent>
 
     <properties>
-        <jenkins.version>1.580.1</jenkins.version>
+        <jenkins.version>2.164.1</jenkins.version>
+        <java.level>8</java.level>
     </properties>
 
+    <groupId>io.jenkins.plugins</groupId>
     <artifactId>build-time-blame</artifactId>
     <version>1.2.2-SNAPSHOT</version>
     <packaging>hpi</packaging>
@@ -66,13 +70,13 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>timestamper</artifactId>
-            <version>1.5.14</version>
+            <version>1.8.7</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>1.8.9</version>
+            <version>2.4.15</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -82,15 +86,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.gmock</groupId>
-            <artifactId>gmock</artifactId>
-            <version>0.8.3</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.spockframework</groupId>
             <artifactId>spock-core</artifactId>
-            <version>0.7-groovy-1.8</version>
+            <version>1.3-groovy-2.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -118,7 +116,7 @@
                 <artifactId>gmaven-plugin</artifactId>
                 <configuration>
                     <providerSelection>2.3</providerSelection>
-                    <source />
+                    <source/>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>build-time-blame</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -104,14 +104,6 @@
         <testSourceDirectory>src/test/groovy</testSourceDirectory>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
-                <configuration>
-                    <tagNameFormat>v@{project.version}</tagNameFormat>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.gmaven</groupId>
                 <artifactId>gmaven-plugin</artifactId>
                 <configuration>
@@ -124,6 +116,22 @@
                         <phase>none</phase>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemProperties>
+                        <property>
+                            <name>hudson.udp</name>
+                            <value>-1</value>
+                        </property>
+                        <property>
+                            <name>java.io.tmpdir</name>
+                            <value>${surefireTempDir}</value>
+                        </property>
+                    </systemProperties>
+                    <runOrder>alphabetical</runOrder>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>

--- a/src/main/groovy/org/jenkins/ci/plugins/buildtimeblame/action/BlameAction.groovy
+++ b/src/main/groovy/org/jenkins/ci/plugins/buildtimeblame/action/BlameAction.groovy
@@ -2,6 +2,7 @@
 
 package org.jenkins.ci.plugins.buildtimeblame.action
 
+import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
 import hudson.model.AbstractProject
 import hudson.model.Action
@@ -21,6 +22,7 @@ import static org.jenkins.ci.plugins.buildtimeblame.io.StaplerUtils.getAsList
 import static org.jenkins.ci.plugins.buildtimeblame.io.StaplerUtils.redirectToParentURI
 
 @ToString(includeNames = true)
+@EqualsAndHashCode
 class BlameAction implements Action {
     static final List<RelevantStep> DEFAULT_PATTERNS = [
             new RelevantStep(~/.*Started by.*/, 'Job Started on Executor', true),
@@ -119,24 +121,5 @@ class BlameAction implements Action {
         }.findAll {
             it != null
         }
-    }
-
-    boolean equals(o) {
-        if (this.is(o)) return true
-        if (getClass() != o.class) return false
-
-        BlameAction that = (BlameAction) o
-
-        if (project != that.project) return false
-        if (relevantSteps.toString() != that.relevantSteps.toString()) return false
-
-        return true
-    }
-
-    int hashCode() {
-        int result
-        result = project.hashCode()
-        result = 31 * result + relevantSteps.hashCode()
-        return result
     }
 }

--- a/src/main/groovy/org/jenkins/ci/plugins/buildtimeblame/io/CustomFileReader.groovy
+++ b/src/main/groovy/org/jenkins/ci/plugins/buildtimeblame/io/CustomFileReader.groovy
@@ -1,16 +1,28 @@
 //  Copyright (c) 2016 Deere & Company
 package org.jenkins.ci.plugins.buildtimeblame.io
 
+import java.util.stream.Stream
+import java.util.stream.StreamSupport
+
 class CustomFileReader {
-    public static void eachLineOnlyLF(InputStream inputStream, Closure closure) {
-        try {
-            Scanner scanner = new Scanner(inputStream)
-            scanner.useDelimiter('\n')
-            while (scanner.hasNext()) {
-                closure.call(scanner.next().trim())
+    public static Stream<String> eachLineOnlyLF(InputStream inputStream) {
+        Scanner scanner = new Scanner(inputStream)
+                .useDelimiter('\n')
+        Iterator<String> iterator = new Iterator<String>() {
+            @Override
+            public boolean hasNext() {
+                return scanner.hasNext()
             }
-        } finally {
-            inputStream.close()
+
+            @Override
+            public String next() {
+                return scanner.next().trim()
+            }
         }
+
+        return StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED | Spliterator.NONNULL),
+                false
+        )
     }
 }

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+    <Match>
+        <Source name="~.*\.groovy" />
+    </Match>
+</FindBugsFilter>

--- a/src/test/groovy/org/jenkins/ci/plugins/buildtimeblame/analysis/LogParserTest.groovy
+++ b/src/test/groovy/org/jenkins/ci/plugins/buildtimeblame/analysis/LogParserTest.groovy
@@ -9,6 +9,8 @@ import org.jenkins.ci.plugins.buildtimeblame.io.CustomFileReader
 import org.jenkins.ci.plugins.buildtimeblame.io.ReportIO
 import spock.lang.Specification
 
+import java.util.stream.Stream
+
 class LogParserTest extends Specification {
     ReportIO reportIO
 
@@ -237,11 +239,8 @@ class LogParserTest extends Specification {
     private void setupMockLog(Run build, String... lines) {
         def mockLog = Mock(InputStream)
         _ * build.getLogInputStream() >> mockLog
-        _ * CustomFileReader.eachLineOnlyLF(mockLog, { Closure action ->
-            for (String line : lines) {
-                action(line)
-            }
-        })
+        _ * CustomFileReader.eachLineOnlyLF(mockLog) >> Stream.of(lines)
+        1 * mockLog.close()
     }
 
     private static List<Timestamp> getRandomTimestamps(int number) {

--- a/src/test/groovy/org/jenkins/ci/plugins/buildtimeblame/io/ReportIOTest.groovy
+++ b/src/test/groovy/org/jenkins/ci/plugins/buildtimeblame/io/ReportIOTest.groovy
@@ -30,7 +30,7 @@ class ReportIOTest extends Specification {
         new ReportIO(build).write(report)
 
         then:
-        getTestFile().text == '[{"label":"Finished","matchedLine":"Did it","previousElapsedTime":50,"timestamp":{"elapsedMillis":1,"millisSinceEpoch":2}}]'
+        getTestFile().text == '[{"label":"Finished","matchedLine":"Did it","previousElapsedTime":50,"timestamp":{"elapsedMillis":1,"elapsedMillisKnown":true,"millisSinceEpoch":2}}]'
     }
 
     def 'should load list from file'() {


### PR DESCRIPTION
The main change used the updated archetype from `mvn -U archetype:generate -Dfilter="io.jenkins.archetypes:"`.

The plugin may still work on Jenkins 1.x but, it is not directly supported. This includes upgrades for Java, Groovy, and Timestamper plugin versions.
