### PR TITLE
Report the elapsed time more logically

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ A Jenkins plugin for analyzing the historical console output of a Job with the g
 
 1. Add/Update regex statements to match parts of the build process.
     + Regex Search Key: Lines in the console output that match this regex string will be added to the report.
-    These keys should match when the particular step is complete.
+    These keys should match when the particular step has begun.
+    Make sure to add another match for when that step is complete or the next begins to get the correct elapsed time in the report.
     + Label: The matches will be shown with this label in the report.
     + Only Use First Match: If this box is checked, the search key will not be checked against after the first line it matches.
 1. (Optional) Set a limit on the "Maximum Builds To Process"

--- a/src/main/groovy/org/jenkins/ci/plugins/buildtimeblame/analysis/BlameReport.groovy
+++ b/src/main/groovy/org/jenkins/ci/plugins/buildtimeblame/analysis/BlameReport.groovy
@@ -76,24 +76,19 @@ class BlameReport {
     private List<ConsoleLogMatch> calculateMeanBuildResult() {
         List<ConsoleLogMatch> meanBuildResult = []
         Multimap<String, ConsoleLogMatch> allBuildResults = getAllBuildResults()
-        def previousElapsedTime = 0
 
         for (String label : allBuildResults.keySet()) {
-            def meanElapsedMillis = getMeanElapsedTime(allBuildResults.get(label).elapsedMillis as List<Long>)
+            def meanElapsedMillis = mean(allBuildResults.get(label).elapsedMillis as List<Long>)
+            def meanElapsedMillisOfNextMatch = mean(allBuildResults.get(label).elapsedMillisOfNextMatch as List<Long>)
 
             meanBuildResult.add(new ConsoleLogMatch(
                     label: label,
                     elapsedMillis: meanElapsedMillis,
                     matchedLine: 'N/A',
-                    previousElapsedTime: previousElapsedTime,
+                    elapsedMillisOfNextMatch: meanElapsedMillisOfNextMatch,
             ))
-            previousElapsedTime = meanElapsedMillis
         }
         return meanBuildResult
-    }
-
-    private static Long getMeanElapsedTime(List<Long> elapsedMillis) {
-        return mean(elapsedMillis)
     }
 
     private static long mean(List<Long> values) {

--- a/src/main/groovy/org/jenkins/ci/plugins/buildtimeblame/analysis/ConsoleLogMatch.groovy
+++ b/src/main/groovy/org/jenkins/ci/plugins/buildtimeblame/analysis/ConsoleLogMatch.groovy
@@ -6,6 +6,8 @@ import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
 import org.apache.commons.lang.time.DurationFormatUtils
 
+import java.beans.Transient
+
 @AutoClone
 @EqualsAndHashCode
 @ToString(includeNames = true)
@@ -15,18 +17,21 @@ class ConsoleLogMatch {
     String label
     String matchedLine
     long elapsedMillis
-    long previousElapsedTime
+    long elapsedMillisOfNextMatch
 
+    @Transient
     String getElapsedTime() {
         format(elapsedMillis)
     }
 
+    @Transient
     String getTimeTaken() {
         format(getUnFormattedTimeTaken())
     }
 
+    @Transient
     long getUnFormattedTimeTaken() {
-        elapsedMillis - previousElapsedTime
+        elapsedMillisOfNextMatch - elapsedMillis
     }
 
     String getMatchedLine() {

--- a/src/main/groovy/org/jenkins/ci/plugins/buildtimeblame/analysis/RelevantStep.groovy
+++ b/src/main/groovy/org/jenkins/ci/plugins/buildtimeblame/analysis/RelevantStep.groovy
@@ -12,7 +12,7 @@ import java.util.regex.Pattern
 @EqualsAndHashCode
 @ToString
 class RelevantStep {
-    @JsonFormat(shape= JsonFormat.Shape.OBJECT)
+    @JsonFormat(shape = JsonFormat.Shape.OBJECT)
     @JsonProperty("key")
     Pattern pattern
     String label

--- a/src/main/groovy/org/jenkins/ci/plugins/buildtimeblame/io/ReportConfiguration.groovy
+++ b/src/main/groovy/org/jenkins/ci/plugins/buildtimeblame/io/ReportConfiguration.groovy
@@ -5,7 +5,7 @@ import groovy.transform.ToString
 import org.jenkins.ci.plugins.buildtimeblame.analysis.RelevantStep
 
 @ToString
-@EqualsAndHashCode(includeFields=true)
+@EqualsAndHashCode
 class ReportConfiguration {
     Integer maxBuilds
     List<RelevantStep> relevantSteps

--- a/src/main/groovy/org/jenkins/ci/plugins/buildtimeblame/io/ReportIO.groovy
+++ b/src/main/groovy/org/jenkins/ci/plugins/buildtimeblame/io/ReportIO.groovy
@@ -1,17 +1,15 @@
 //  Copyright (c) 2016 Deere & Company
 package org.jenkins.ci.plugins.buildtimeblame.io
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import hudson.model.Run
-import net.sf.json.JSONObject
-import net.sf.json.JsonConfig
-import net.sf.json.util.PropertyFilter
 import org.jenkins.ci.plugins.buildtimeblame.analysis.ConsoleLogMatch
 
-import static net.sf.json.JSONArray.fromObject
 import static org.jenkins.ci.plugins.buildtimeblame.io.BlameFilePaths.getReportFile
 
 class ReportIO {
     Run build
+    private static ObjectMapper objectMapper = new ObjectMapper()
 
     public static ReportIO getInstance(Run build) {
         return new ReportIO(build)
@@ -26,38 +24,17 @@ class ReportIO {
     }
 
     public void write(List<ConsoleLogMatch> report) {
-        getReportFile(build).write(getJSON(report))
+        getReportFile(build).write(objectMapper.writeValueAsString(report))
     }
 
     public Optional<List<ConsoleLogMatch>> readFile() {
         try {
-            Optional.of(fromObject(getReportFile(build).text).collect { JSONObject object -> mapToMatch(object) })
+            def reportContent = getReportFile(build).text
+            def report = objectMapper.readValue(reportContent, ConsoleLogMatch[])
+
+            return Optional.of(Arrays.asList(report))
         } catch (Exception ignored) {
             return Optional.empty()
         }
-    }
-
-    private static String getJSON(List<ConsoleLogMatch> report) {
-        fromObject(report, getConfig()).toString()
-    }
-
-    private static ConsoleLogMatch mapToMatch(JSONObject object) {
-        new ConsoleLogMatch(
-                label: object.get('label'),
-                matchedLine: object.get('matchedLine'),
-                previousElapsedTime: object.get('previousElapsedTime') as long,
-                elapsedMillis: object.get('elapsedMillis') as long
-        )
-    }
-
-    private static JsonConfig getConfig() {
-        def jsonConfig = new JsonConfig()
-        jsonConfig.setJsonPropertyFilter(new PropertyFilter() {
-            @Override
-            boolean apply(Object source, String name, Object value) {
-                return name.equals('timeTaken') || name.equals('elapsedTime') || name.equals('unFormattedTimeTaken')
-            }
-        })
-        return jsonConfig
     }
 }

--- a/src/test/groovy/org/jenkins/ci/plugins/buildtimeblame/analysis/ConsoleLogMatchTest.groovy
+++ b/src/test/groovy/org/jenkins/ci/plugins/buildtimeblame/analysis/ConsoleLogMatchTest.groovy
@@ -4,7 +4,6 @@ package org.jenkins.ci.plugins.buildtimeblame.analysis
 import groovy.transform.AutoClone
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
-import hudson.plugins.timestamper.Timestamp
 import spock.lang.Specification
 
 class ConsoleLogMatchTest extends Specification {
@@ -25,7 +24,7 @@ class ConsoleLogMatchTest extends Specification {
 
     def 'should return formatted time taken'() {
         given:
-        def logResult = new ConsoleLogMatch(elapsedMillis: 500015, previousElapsedTime: 50)
+        def logResult = new ConsoleLogMatch(elapsedMillis: 50, elapsedMillisOfNextMatch: 500015)
 
         expect:
         logResult.getTimeTaken() == '08:19.965'
@@ -33,7 +32,7 @@ class ConsoleLogMatchTest extends Specification {
 
     def 'should return un-formatted time taken'() {
         given:
-        def logResult = new ConsoleLogMatch(elapsedMillis: 465, previousElapsedTime: 15)
+        def logResult = new ConsoleLogMatch(elapsedMillis: 15, elapsedMillisOfNextMatch: 465)
 
         expect:
         logResult.getUnFormattedTimeTaken() == 450

--- a/src/test/groovy/org/jenkins/ci/plugins/buildtimeblame/io/ReportIOTest.groovy
+++ b/src/test/groovy/org/jenkins/ci/plugins/buildtimeblame/io/ReportIOTest.groovy
@@ -1,8 +1,8 @@
 //  Copyright (c) 2016 Deere & Company
 package org.jenkins.ci.plugins.buildtimeblame.io
 
-import org.jenkins.ci.plugins.buildtimeblame.analysis.ConsoleLogMatch
 import hudson.model.Run
+import org.jenkins.ci.plugins.buildtimeblame.analysis.ConsoleLogMatch
 import spock.lang.Specification
 
 class ReportIOTest extends Specification {
@@ -21,35 +21,35 @@ class ReportIOTest extends Specification {
     def 'should serialize list to file without derived fields'() {
         given:
         def report = [
-                new ConsoleLogMatch(label: 'Finished', matchedLine: 'Did it', previousElapsedTime: 50, elapsedMillis: 1),
+                new ConsoleLogMatch(label: 'Finished', matchedLine: 'Did it', elapsedMillisOfNextMatch: 50, elapsedMillis: 1),
         ]
 
         when:
         new ReportIO(build).write(report)
 
         then:
-        getTestFile().text == '[{"matchedLine":"Did it","previousElapsedTime":50,"label":"Finished","elapsedMillis":1}]'
+        getTestFile().text == '[{"label":"Finished","matchedLine":"Did it","elapsedMillis":1,"elapsedMillisOfNextMatch":50}]'
     }
 
     def 'should load list from file'() {
         given:
-        getTestFile().write('[{"label":"Finished","matchedLine":"Did it","previousElapsedTime":50,"elapsedMillis":1}]')
+        getTestFile().write('[{"label":"Finished","matchedLine":"Did it","elapsedMillisOfNextMatch":50,"elapsedMillis":1}]')
 
         when:
         def report = new ReportIO(build).readFile().get()
 
         then:
         report == [
-                new ConsoleLogMatch(label: 'Finished', matchedLine: 'Did it', previousElapsedTime: 50, elapsedMillis: 1),
+                new ConsoleLogMatch(label: 'Finished', matchedLine: 'Did it', elapsedMillisOfNextMatch: 50, elapsedMillis: 1),
         ]
     }
 
     def 'should use same format for read and write'() {
         given:
         def expected = [
-                new ConsoleLogMatch(label: 'Begin', matchedLine: 'Did it', previousElapsedTime: 50, elapsedMillis: 1),
-                new ConsoleLogMatch(label: 'Started', matchedLine: 'Did nothing', previousElapsedTime: 30, elapsedMillis: 3),
-                new ConsoleLogMatch(label: 'Finished', matchedLine: 'Did all', previousElapsedTime: 21, elapsedMillis: 5),
+                new ConsoleLogMatch(label: 'Begin', matchedLine: 'Did it', elapsedMillisOfNextMatch: 50, elapsedMillis: 1),
+                new ConsoleLogMatch(label: 'Started', matchedLine: 'Did nothing', elapsedMillisOfNextMatch: 30, elapsedMillis: 3),
+                new ConsoleLogMatch(label: 'Finished', matchedLine: 'Did all', elapsedMillisOfNextMatch: 21, elapsedMillis: 5),
         ]
 
         when:


### PR DESCRIPTION
Rather than look at the elapsed time of the previous match, look at the next match for the duration of the current label. The last timestamp for the build is used on the last match.

This means that the labels can be set for when a "stage" of the build begins and will be correct as long as there is a label for when that "stage" ends.

Closes #14.

This is the last in a series of PRs for the 2.0.0 release. The notes will include full migration steps. Though, they shouldn't be too troublesome.