### PR TITLE
Fix error finding timestamps for builds

### DIFF
--- a/src/main/groovy/org/jenkins/ci/plugins/buildtimeblame/analysis/TimedLog.groovy
+++ b/src/main/groovy/org/jenkins/ci/plugins/buildtimeblame/analysis/TimedLog.groovy
@@ -1,6 +1,7 @@
 package org.jenkins.ci.plugins.buildtimeblame.analysis
 
 import groovy.transform.EqualsAndHashCode
+import org.apache.commons.lang3.StringUtils
 
 import java.util.stream.Collectors
 
@@ -16,11 +17,16 @@ class TimedLog {
             )
         } else {
             def split = timestamperLog.split(' ')
-
-            return new TimedLog(
+            if (StringUtils.isNumeric(split[0])) {
+                return new TimedLog(
                     elapsedMillis: Optional.of(Long.valueOf(split[0])),
                     log: Arrays.stream(split).skip(1).collect(Collectors.joining(' ')),
-            )
+                )
+            } else {
+                return new TimedLog(
+                        log: timestamperLog.trim()
+                )
+            }
         }
     }
 

--- a/src/test/groovy/org/jenkins/ci/plugins/buildtimeblame/analysis/TimedLogTest.groovy
+++ b/src/test/groovy/org/jenkins/ci/plugins/buildtimeblame/analysis/TimedLogTest.groovy
@@ -30,6 +30,19 @@ class TimedLogTest extends Specification {
         !result.elapsedMillis.isPresent()
     }
 
+    def 'should not fail upon unexpected log format'() {
+        given:
+        def log = 'some text for what happened'
+        def text = "$log"
+
+        when:
+        def result = TimedLog.fromText(text)
+
+        then:
+        result.log == log
+        !result.elapsedMillis.isPresent()
+    }
+
     def 'should convert to a log line and back again when there is a timestamp'() {
         given:
         def log = 'some text for what happened'


### PR DESCRIPTION
Fixes #27 
It crashed when the console output contained lines which are not started with ' ' nor with timestamp.
E.g. maven dependency download progress lines:

> 76125  Progress (1): 4.1/10 kB
Progress (1): 7.4/10 kB
Progress (1): 10 kB    
Progress (2): 10 kB | 4.1/20 kB
Progress (2): 10 kB | 7.2/20 kB
Progress (2): 10 kB | 11/20 kB 
Progress (2): 10 kB | 15/20 kB
Progress (2): 10 kB | 19/20 kB
Progress (2): 10 kB | 20 kB   