### PR TITLE
Set lower Jenkins version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     </parent>
 
     <properties>
-        <jenkins.version>2.235.2</jenkins.version>
+        <jenkins.version>2.164.1</jenkins.version>
         <java.level>8</java.level>
         <slf4j.version>1.7.26</slf4j.version>
     </properties>


### PR DESCRIPTION
Jenkins uses the build plugin version as a minimum and disallows installing the plugin if that is not satisfied. This should be the true minimum for using this plugin. Closes #31.  