### PR TITLE
Allow more build labels to be shown

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     </parent>
 
     <properties>
-        <jenkins.version>2.164.1</jenkins.version>
+        <jenkins.version>2.164.3</jenkins.version>
         <java.level>8</java.level>
         <slf4j.version>1.7.26</slf4j.version>
     </properties>

--- a/src/main/groovy/org/jenkins/ci/plugins/buildtimeblame/analysis/BlameReport.groovy
+++ b/src/main/groovy/org/jenkins/ci/plugins/buildtimeblame/analysis/BlameReport.groovy
@@ -8,6 +8,7 @@ import groovy.transform.ToString
 import hudson.util.Graph
 import org.jfree.chart.ChartFactory
 import org.jfree.chart.JFreeChart
+import org.jfree.chart.axis.CategoryLabelPositions
 import org.jfree.chart.plot.PlotOrientation
 import org.jfree.data.category.CategoryDataset
 import org.jfree.data.category.DefaultCategoryDataset
@@ -53,7 +54,10 @@ class BlameReport {
                     '', 'Build #', 'Time Taken (s)', getDataSet(),
                     PlotOrientation.VERTICAL, true, false, false
             ).each {
-                it.getCategoryPlot().getDomainAxis().setCategoryMargin(0)
+                def xAxis = it.getCategoryPlot().getDomainAxis()
+
+                xAxis.setCategoryMargin(0)
+                xAxis.setCategoryLabelPositions(CategoryLabelPositions.UP_45);
             }
         }
     }


### PR DESCRIPTION
The graph is probably not very useful with more builds than can we can show with this angle. Closes #34.

Before:
![image](https://user-images.githubusercontent.com/6852365/141662725-a83b95bf-0bad-415c-84bb-502d80867dea.png)

After:
![image](https://user-images.githubusercontent.com/6852365/141662684-c0323cb3-3d8d-4478-808c-38ca9adcaf8c.png)
