### PR TITLE
Adapt icon path removal from core

### DIFF
--- a/src/main/groovy/org/jenkins/ci/plugins/buildtimeblame/action/BlameAction.groovy
+++ b/src/main/groovy/org/jenkins/ci/plugins/buildtimeblame/action/BlameAction.groovy
@@ -44,12 +44,16 @@ class BlameAction implements Action {
 
     @Override
     String getIconFileName() {
-        return 'monitor.png'
+        return 'null'
     }
 
     @Override
     String getDisplayName() {
         return 'Build Time Blame Report'
+    }
+
+    String getIconClassName() {
+        return 'icon-monitor'
     }
 
     @Override

--- a/src/main/resources/org/jenkins/ci/plugins/buildtimeblame/action/BlameAction/action.jelly
+++ b/src/main/resources/org/jenkins/ci/plugins/buildtimeblame/action/BlameAction/action.jelly
@@ -3,6 +3,6 @@
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
-    <l:task icon="images/24x24/${action.getIconFileName()}" href="${h.getActionUrl(it.url,action)}"
+    <l:task icon="${action.getIconClassName()} icon-md" href="${h.getActionUrl(it.url,action)}"
             title="${action.getDisplayName()}" permission="${app.READ}"/>
 </j:jelly>

--- a/src/test/groovy/org/jenkins/ci/plugins/buildtimeblame/action/BlameActionTest.groovy
+++ b/src/test/groovy/org/jenkins/ci/plugins/buildtimeblame/action/BlameActionTest.groovy
@@ -34,7 +34,7 @@ class BlameActionTest extends Specification {
         Action blameAction = new BlameAction(null);
 
         then:
-        blameAction.getIconFileName() == 'monitor.png'
+        blameAction.getIconClassName() == 'icon-monitor'
         blameAction.getDisplayName() == 'Build Time Blame Report'
         blameAction.getUrlName() == 'buildTimeBlameReport'
     }


### PR DESCRIPTION
The change proposed prepares the plugin for the icon path removal from core in the upcoming LTS line. This change affects plugins not using the icon API or relying on paths. Plugins using the API properly in the first place are unaffected by this change.

Could you trigger a release after merging this PR please, giving people a chance to update the plugin before updating to the next LTS version @LTegtmeier  
Thanks in advance!