### PR TITLE
Upgrade script-security for dependabot patches

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.46</version>
+            <version>[1.56,)</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>[1.56,)</version>
+            <version>1.56</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This is only a compile dependency. So, there's no need to make a release with the update.