### PR TITLE
Make dependabot happy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <jenkins.version>2.289.1</jenkins.version>
         <java.level>8</java.level>
-        <slf4j.version>1.7.26</slf4j.version>
+        <slf4j.version>1.7.30</slf4j.version>
         <revision>2.0.4</revision>
         <changelist>999999-SNAPSHOT</changelist>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     </parent>
 
     <properties>
-        <jenkins.version>2.164.3</jenkins.version>
+        <jenkins.version>2.289.1</jenkins.version>
         <java.level>8</java.level>
         <slf4j.version>1.7.26</slf4j.version>
         <revision>2.0.4</revision>
@@ -101,13 +101,13 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.56</version>
+            <version>1.75</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>mailer</artifactId>
-            <version>1.20</version>
+            <version>414.vcc4c33714601</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION


Replaces #44 and #46 to close vulnerabilities that aren't really in the plugin since they are only `compile` dependencies that the parent pom requires me to specify. The plugin will still work with older Jenkins versions but, will warn if the version is < 2.289.1.