### PR TITLE
Fix index sync with plugins.jenkins.io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         A Jenkins plugin for analyzing the historical console output of a Job
         with the goal of determining which steps are taking the most time.
     </description>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Build+Time+Blame+Plugin</url>
+    <url>https://github.com/jenkinsci/build-time-blame-plugin/</url>
 
     <repositories>
         <repository>


### PR DESCRIPTION
The [plugin page](https://plugins.jenkins.io/build-time-blame/) points to wiki.jenkins-ci.org for legacy reasons, causing the plugin page to load legacy content only:

![Screenshot 2023-10-07 at 06 47 37](https://github.com/jenkinsci/build-time-blame-plugin/assets/13383509/4b2e05b2-beb9-4a25-9b64-3ea16bba8e49)

The change proposed updates the `<url>` field matching the GitHub repository, starting to populate the README.md content on plugins.jenkins.io upon release, as it's done since the wiki.jenkins-ci.org break.