### PR TITLE
Fix cast exception when a run has a missing step

### DIFF
--- a/src/main/groovy/org/jenkins/ci/plugins/buildtimeblame/analysis/BlameReport.groovy
+++ b/src/main/groovy/org/jenkins/ci/plugins/buildtimeblame/analysis/BlameReport.groovy
@@ -80,7 +80,8 @@ class BlameReport {
         public String generateToolTip(CategoryDataset dataset, int row, int column) {
             String rowKey = dataset.getRowKey(row)
             int columnKey = dataset.getColumnKey(column)
-            double elapsedSeconds = dataset.getValue(rowKey, columnKey)
+            def value = dataset.getValue(rowKey, columnKey) ?: 0.0
+            double elapsedSeconds = value
             long elapsedMillis = 1000.0 * elapsedSeconds
             String duration = DurationFormatUtils.formatDuration(elapsedMillis, 'mm:ss.S')
 

--- a/src/test/groovy/org/jenkins/ci/plugins/buildtimeblame/analysis/BlameReportTest.groovy
+++ b/src/test/groovy/org/jenkins/ci/plugins/buildtimeblame/analysis/BlameReportTest.groovy
@@ -181,6 +181,29 @@ class BlameReportTest extends Specification {
         url.contains("${buildNumber}")
     }
 
+    def 'should handle missing steps in build result'() {
+        given:
+        def buildNumber = 66
+        def dataSet = new DefaultCategoryDataset()
+        dataSet.addValue((double) 1.0, 'Compile', buildNumber)
+        dataSet.addValue((double) 2.0, 'Compile', 31)
+        dataSet.addValue((double) 3.0, 'Test', 31)
+
+        def report = new BlameReport([])
+        def chart = report.getGraph().createGraph()
+        def toolTipGenerator = chart.getCategoryPlot().getRenderer().getToolTipGenerator(1, 0)
+        def urlGenerator = chart.getCategoryPlot().getRenderer().getItemURLGenerator(1, 0)
+
+        when:
+        def toolTip = toolTipGenerator.generateToolTip(dataSet, 1, 0)
+        def url = urlGenerator.generateURL(dataSet, 1, 0)
+
+        then:
+        toolTip != null
+        toolTip.contains('0s')
+        url != null
+    }
+
     CategoryDataset getExpectedDataSet() {
         def dataSet = new DefaultCategoryDataset()
 


### PR DESCRIPTION
This caused map fetch errors unless all displayed runs included the same steps. When the map fetch failed, the graph was missing the tooltips and run links added in #59

Fixed by using 0.0 as a default value when dataset.getValue(...) returns null

Closes #61

### Testing done

Tested with hpi:run and sample data which reproduced the error on the current release.

Also added a new test covering this case, having first confirmed that it detects the bug when the fix is not applied.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```